### PR TITLE
Fix portfolio item navigation on mobile

### DIFF
--- a/src/views/PortfolioView.vue
+++ b/src/views/PortfolioView.vue
@@ -26,6 +26,7 @@
 
 <script setup>
 import { ref, onMounted, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
 import { preloadImages } from '@/composables/useImagePreloader.js'
 import PortfolioList from '@/components/PortfolioList.vue'
 import { usePortfolio } from '@/composables/usePortfolio.js'
@@ -34,6 +35,11 @@ import Masonry from 'masonry-layout'
 const displayedWorks = ref([]) // 實際顯示的作品
 const { portfolioData } = usePortfolio()
 const imagesLoaded = ref(false)
+const router = useRouter()
+
+function handleViewDetails(work) {
+  router.push(`/project/${work.id}`)
+}
 
 // 瀑布流重新計算
 const recalculateMasonryLayout = () => {


### PR DESCRIPTION
## Summary
- ensure PortfolioView defines `handleViewDetails`
- route to project detail when a portfolio item is clicked

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ad03abb48323909bc20f700fe97c