### PR TITLE
Fix lightbox composable initialization

### DIFF
--- a/src/composables/useLightBox.js
+++ b/src/composables/useLightBox.js
@@ -52,6 +52,8 @@ function openLightbox(src, alt) {
   document.body.appendChild(modal)
 }
 
-onMounted(() => {
-  enableImageLightbox()
-})
+export function useLightBox() {
+  onMounted(() => {
+    enableImageLightbox()
+  })
+}


### PR DESCRIPTION
## Summary
- address warning "onMounted is called when there is no active component instance" by providing a `useLightBox` composable

## Testing
- `npm run lint:check`
- `npm run format:check`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_6847f9a7b6708323a761cb3f82953301