### PR TITLE
Fix test coverage setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm run format:check # 檢查格式化狀態
 npm run test         # 開發模式測試
 npm run test:run     # 單次執行測試
 npm run test:ui      # 測試 UI 介面
-npm run test:coverage # 測試覆蓋率
+npm run test:coverage # 測試覆蓋率 (需安裝 @vitest/coverage-v8)
 ```
 
 ### 完整品質檢查

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "sass-embedded": "^1.89.1",
     "vite": "^6.2.4",
     "vite-plugin-vue-devtools": "^7.7.2",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "@vitest/coverage-v8": "^3.2.3"
   }
 }


### PR DESCRIPTION
## Summary
- enable Vitest coverage plugin in dependencies
- document the new coverage plugin requirement

## Testing
- `npm run test:run`
- `npm run lint:check`
- `npm run format:check`
- `npm run test:coverage` *(fails: MISSING DEPENDENCY)*

------
https://chatgpt.com/codex/tasks/task_e_684801973bb083238105389a36969a69