### PR TITLE
Fix GH Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     needs: lint-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- ensure the deploy job can push to `gh-pages`

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68480783adf883238b86240b508d5851